### PR TITLE
Added support for Windows including Menubar

### DIFF
--- a/client/scripts/bootstrap.js
+++ b/client/scripts/bootstrap.js
@@ -1,11 +1,15 @@
-import React        from "react";
-import { render }   from "react-dom";
-import App          from "./components/App.react";
+import React from "react";
+import { render } from "react-dom";
+import App from "./components/App.react";
+const { Window } = nw;
 
-const MainMenu   = require( "./natives/MainMenuNative" )();
+const mainWin = Window.get();
+const MainMenu = require("./natives/MainMenuNative")();
 
-require( "./natives/FileMenuNative" )( MainMenu );
-require( "./natives/FormatMenuNative" )( MainMenu );
-require( "./natives/AboutMenuNative" )( MainMenu );
+require("./natives/FileMenuNative")(MainMenu);
+require("./natives/FormatMenuNative")(MainMenu);
+require("./natives/AboutMenuNative")(MainMenu);
 
-render( <App />, document.getElementById( "app" ) );
+mainWin.menu = MainMenu; //menu should be added here, because it appears empty on windows if it is bound to the window before it's children are appended
+
+render(<App />, document.getElementById("app"));

--- a/client/scripts/natives/MainMenuNative.js
+++ b/client/scripts/natives/MainMenuNative.js
@@ -1,10 +1,13 @@
 export default () => {
-    const { Menu, Window } = nw;
-    const mainWin          = Window.get();
-    const mainMenu         = new Menu( { type : "menubar" } );
+    const { Menu } = nw;
 
-    mainMenu.createMacBuiltin( "Qilin" );
-    mainWin.menu = mainMenu;
+    const mainMenu = new Menu({ type: "menubar" });
+
+    if (process.platform === "darwin") { //check if current OS is MacOS, createMacBuiltin crashes the app on Windows and possibly on Linux
+        mainMenu.createMacBuiltin("Qilin");
+    }
+
+
 
     return mainMenu;
 };


### PR DESCRIPTION
- `createMacBuiltin` is now called only on MacOS (the app won't crash on Windows and _possibly_ Linux)
- Menubar is being bound to the window _after_ it's children have been populated. Without this fix the menu would appear empty on Windows.