### PR TITLE
fix(package): update markdown-it-anchor to version 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "keymage": "^1.1.3",
     "markdown-it": "^8.4.1",
     "markdown-it-abbr": "^1.0.4",
-    "markdown-it-anchor": "^4.0.0",
+    "markdown-it-anchor": "^5.0.2",
     "markdown-it-block-embed": "^0.0.3",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-maths": "1.0.8",


### PR DESCRIPTION
Closes #77