### PR TITLE
fix(package): update markdown-it-table-of-contents to version 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "markdown-it-maths": "1.0.8",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
-    "markdown-it-table-of-contents": "^0.3.3",
+    "markdown-it-table-of-contents": "^0.4.3",
     "markdown-it-task-lists": "^2.1.1",
     "material-icons-react": "^1.0.0",
     "mobx": "^4.1.1",


### PR DESCRIPTION
Closes #79